### PR TITLE
Fix blocking sleep

### DIFF
--- a/idotmatrix/connectionManager.py
+++ b/idotmatrix/connectionManager.py
@@ -1,7 +1,7 @@
+from asyncio import sleep
 from bleak import BleakClient, BleakScanner, AdvertisementData
 from .const import UUID_READ_DATA, UUID_WRITE_DATA, BLUETOOTH_DEVICE_NAME
 import logging
-import time
 from typing import List, Optional
 
 
@@ -78,7 +78,7 @@ class ConnectionManager(metaclass=SingletonMeta):
                 data,
                 response,
             )
-            time.sleep(0.01)
+            await sleep(0.01)
             return True
 
     async def read(self) -> bytes:


### PR DESCRIPTION
I am trying to create a Home Assistant integration using your library (thank you for your work!), and HA warned me about a blocking call to sleep.

So, I changed it from time.sleep to asyncio.sleep to resolve the issue.

I ran the tests, and they worked fine with the change. Additionally, HA no longer warns about any blocking calls.